### PR TITLE
Add main entry point for encoder

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,5 +11,11 @@ Style/ClassAndModuleChildren:
   Exclude:
     - 'test/**/*'
 
+Style/Documentation:
+  Enabled: false
+
+Style/LambdaCall:
+  EnforcedStyle: braces
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/emv-qr.gemspec
+++ b/emv-qr.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |spec|
 
   # Runtime dependencies.
   #
-  spec.add_runtime_dependency "dry-schema", "~> 1.4"
+  spec.add_runtime_dependency "dry-schema",      "~> 1.4"
+  spec.add_runtime_dependency "dry-transaction", "~> 0.13"
 
   # Development dependencies.
   #

--- a/lib/emv_qr.rb
+++ b/lib/emv_qr.rb
@@ -3,3 +3,11 @@
 require_relative "emv_qr/version"
 
 require_relative "emv_qr/schema"
+require_relative "emv_qr/encode"
+
+module EmvQr
+  def encode(data)
+    Encode.new.(data)
+  end
+  module_function :encode
+end

--- a/lib/emv_qr/encode.rb
+++ b/lib/emv_qr/encode.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "dry-transaction"
+
+module EmvQr
+  # The EMV QR specification limits the payload to a length of
+  # 512 characters, but also states the length should be reduced
+  # proportionally when using multi-byte characters. This is
+  # essentially the same as saying the maximum payload size is
+  # 512 bytes.
+  #
+  MAXIMUM_PAYLOAD_BYTE_SIZE = 512
+
+  # Transaction that serves encapsulates the main entry point
+  # of the encoder.
+  #
+  class Encode
+    include Dry::Transaction
+
+    step :validate_input
+    step :construct_payload
+    step :calculate_checksum
+    step :validate_payload_size
+
+    private
+
+    def validate_input(input)
+      Schema.new.(input).to_monad
+    end
+
+    def construct_payload(input)
+      Success(input)
+      # TODO: Implement
+    end
+
+    def calculate_checksum(input)
+      Success(input)
+      # TODO: Implement
+    end
+
+    def validate_payload_size(input)
+      Success(input)
+      # TODO: Implement
+    end
+  end
+  private_constant :Encode
+end

--- a/lib/emv_qr/schema.rb
+++ b/lib/emv_qr/schema.rb
@@ -2,7 +2,7 @@
 
 require "dry-schema"
 
-Dry::Schema.load_extensions(:hints)
+Dry::Schema.load_extensions(:monads)
 
 module EmvQr
   # This class defines a schema for the input format expected by the
@@ -164,4 +164,5 @@ module EmvQr
       end
     end
   end
+  private_constant :Schema
 end


### PR DESCRIPTION
### What is this change?

This PR adds the `EmvQr.encode` entry point, and a transaction class `EmvQr::Encode` which defines the steps required for taking the data from input format to EMV QR Code string.

The first step, input validation, was added in the previous PR.